### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/node-build.ts
+++ b/node-build.ts
@@ -2,10 +2,16 @@ import path from "path";
 import { createServer } from "./index";
 import * as express from "express";
 import path from "node:path";
+import rateLimit from "express-rate-limit";
 
 const app = createServer();
 const port = process.env.PORT || 3000;
 
+// Configure rate limiter for SPA file serving
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+});
 // In production, serve the built SPA files
 const __dirname = import.meta.dirname;
 const distPath = path.join(__dirname, "../spa");
@@ -13,8 +19,8 @@ const distPath = path.join(__dirname, "../spa");
 // Serve static files
 app.use(express.static(distPath));
 
-// Handle React Router - serve index.html for all non-API routes
-app.get(/.*/, (req, res) => {
+// Handle React Router - serve index.html for all non-API routes, with rate limiting
+app.get(/.*/, limiter, (req, res) => {
   // Don't serve index.html for API routes
   if (req.path.startsWith("/api/") || req.path.startsWith("/health")) {
     return res.status(404).json({ error: "API endpoint not found" });


### PR DESCRIPTION
Potential fix for [https://github.com/freepalestinesh/freepalestine.sh/security/code-scanning/1](https://github.com/freepalestinesh/freepalestine.sh/security/code-scanning/1)

To fix the missing rate limiting vulnerability, a rate-limiting middleware should be applied to requests served by the handler at line 17. The best way is to use the well-known `express-rate-limit` package. This middleware can be applied globally (`app.use(limiter)`) or just to the relevant handler route (`app.get(..., limiter, handler)`). For clarity and to avoid unintended side effects on API routes, the rate limiter should be applied specifically to the non-API routes (i.e., the catch-all route that serves `index.html`). This requires:
- Installing `express-rate-limit`
- Importing it in the file
- Creating a rate limiter instance with reasonable settings (e.g., up to 100 requests per 15 minutes per IP)
- Adding it as middleware to the SPA route handler (line 17).

Because only code in node-build.ts is shown, the fix is strictly confined there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
