### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete HTML attribute sanitization

### DIFF
--- a/client/lib/posts.ts
+++ b/client/lib/posts.ts
@@ -12,7 +12,13 @@ export type Post = {
 };
 
 function escapeHtml(s: string) {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  // Escape &, <, >, ", and ' for use in HTML attributes or text
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 function simpleMarkdownToHtml(md: string) {


### PR DESCRIPTION
Potential fix for [https://github.com/freepalestinesh/freepalestine.sh/security/code-scanning/4](https://github.com/freepalestinesh/freepalestine.sh/security/code-scanning/4)

To prevent XSS in this context, values interpolated into HTML attribute values must have all relevant HTML meta-characters escaped, especially double quotes (`"`), ampersand (`&`), less than (`<`), and greater than (`>`). The best fix is to enhance the `escapeHtml` function to also escape double quotes, and ideally single quotes as well. In the file `client/lib/posts.ts`, change the implementation of `escapeHtml` so that it escapes `&`, `<`, `>`, `"`, and `'`. This will ensure the subsequent usage of `escapeHtml(b)` in constructing attribute values is secure. The changes are limited to the `escapeHtml` function definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
